### PR TITLE
Fix bug that prevents using it with code from README

### DIFF
--- a/src/js/color-picker.js
+++ b/src/js/color-picker.js
@@ -227,6 +227,7 @@ function ColorPickerControl(cfg) {
      *  Event function
      */
     this.on = function(event, fn) {
+        eventListeners[event] = eventListeners[event] || [];
         eventListeners[event].push(fn);
         return this;
     }


### PR DESCRIPTION
On startup the following code from the `README` does not work with the current `master` branch:

```javascript
const picker = new ColorPickerControl({ 
    container: document.body, 
    theme: 'light' 
});

picker.on('init', (instance) => {
    console.log('Event: "init"', instance);
});
picker.on('open', (instance) => {
    console.log('Event: "open"', instance);
});
picker.on('change', (color) => {
    console.log('Event: "change"', color);
});
picker.on('close', (instance) => {
    console.log('Event: "close"', instance);
});

```

This is because `eventListeners[event]` is not initialized and so the `push` operation fails. This change lazily initializes the event type in `eventListeners` and resolves the issue without having to explicitly initialize each event.